### PR TITLE
Check for unsaved changes before navigation (#156)

### DIFF
--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -12,6 +12,7 @@ use Filament\Pages;
 use Filament\Panel;
 use Filament\PanelProvider;
 use Filament\Support\Colors\Color;
+use Filament\Support\Facades\FilamentView;
 use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
 use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
@@ -19,9 +20,20 @@ use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Session\Middleware\AuthenticateSession;
 use Illuminate\Session\Middleware\StartSession;
 use Illuminate\View\Middleware\ShareErrorsFromSession;
+use Illuminate\View\View;
 
 class AdminPanelProvider extends PanelProvider
 {
+    public function register(): void
+    {
+        parent::register();
+
+        FilamentView::registerRenderHook(
+            'panels::body.end',
+            static fn(): View => view('filament.partials.footer-scripts'),
+        );
+    }
+
     public function panel(Panel $panel): Panel
     {
         return $panel
@@ -29,39 +41,39 @@ class AdminPanelProvider extends PanelProvider
             ->id('admin')
             ->path('admin')
             ->login(Login::class)
-			->globalSearchKeyBindings(['command+k', 'ctrl+k'])
-			->maxContentWidth('full')
+            ->globalSearchKeyBindings(['command+k', 'ctrl+k'])
+            ->maxContentWidth('full')
             ->colors([
-				'primary' => [
-					50 => '#eafff7',
-					100 => '#cdfeeb',
-					200 => '#a0fadc',
-					300 => '#63f2ca',
-					400 => '#25e2b3',
-					500 => '#00c49a',
-					600 => '#00a481',
-					700 => '#00836b',
-					800 => '#006756',
-					900 => '#005548',
-					950 => '#00302a',
-				],
-				'danger' => Color::Rose,
+                'primary' => [
+                    50 => '#eafff7',
+                    100 => '#cdfeeb',
+                    200 => '#a0fadc',
+                    300 => '#63f2ca',
+                    400 => '#25e2b3',
+                    500 => '#00c49a',
+                    600 => '#00a481',
+                    700 => '#00836b',
+                    800 => '#006756',
+                    900 => '#005548',
+                    950 => '#00302a',
+                ],
+                'danger' => Color::Rose,
             ])
-			->favicon(asset_url("avatar.png"))
+            ->favicon(asset_url("avatar.png"))
             ->discoverResources(in: app_path('Filament/Resources'), for: 'App\\Filament\\Resources')
             ->discoverPages(in: app_path('Filament/Pages'), for: 'App\\Filament\\Pages')
-			->navigationGroups([
-				NavigationGroup::make('Content'),
-				NavigationGroup::make('Administration'),
-			])
+            ->navigationGroups([
+                NavigationGroup::make('Content'),
+                NavigationGroup::make('Administration'),
+            ])
             ->pages([
                 Pages\Dashboard::class,
             ])
             ->widgets([
                 \Filament\Widgets\AccountWidget::class,
                 \Filament\Widgets\FilamentInfoWidget::class,
-				Widgets\LatestPosts::class,
-				Widgets\CommandLog::class,
+                Widgets\LatestPosts::class,
+                Widgets\CommandLog::class,
             ])
             ->middleware([
                 EncryptCookies::class,

--- a/resources/js/GeneralTypes.ts
+++ b/resources/js/GeneralTypes.ts
@@ -1,0 +1,3 @@
+export interface BasicObject<T> {
+	[key: string]: T
+}

--- a/resources/js/admin/DirtyStatesRegister.ts
+++ b/resources/js/admin/DirtyStatesRegister.ts
@@ -1,0 +1,71 @@
+import {BasicObject} from '../GeneralTypes'
+
+export class DirtyStatesRegister {
+	confirmEvents: string[] = []
+
+	states: BasicObject<boolean> = {}
+
+	constructor(events: string[] = []) {
+		this.states = {}
+		this.confirmEvents = ['beforeunload'].concat(events)
+
+		this.confirmEvents.forEach(name =>
+			window.addEventListener(name, this.triggerConfirm),
+		)
+
+		window.addEventListener('reportDirtyState', this.setState.bind(this))
+		window.addEventListener('checkDirtyState', this.getState.bind(this))
+		window.addEventListener('forgetDirtyState', this.unsetState.bind(this))
+
+		console.info('Dirty States Register init')
+	}
+
+	get isClean(): boolean {
+		return !Object.values(this.states).includes(true)
+	}
+
+	getState({
+		target,
+		detail: {hashVal, emitBack},
+	}: {
+		target: EventTarget
+		detail: {
+			hashVal: string
+			emitBack: string
+		}
+	}): void {
+		target.dispatchEvent(
+			new CustomEvent(emitBack, {
+				detail: {isDirty: this.states[hashVal]},
+			}),
+		)
+	}
+
+	setState({
+		detail: {hashVal, isDirty},
+	}: {
+		detail: {
+			hashVal: string
+			isDirty: boolean
+		}
+	}): void {
+		this.states[hashVal] = isDirty
+	}
+
+	unsetState({detail: {hashVal}}: {detail: {hashVal: string}}): void {
+		delete this.states[hashVal]
+	}
+
+	triggerConfirm(e: Event): boolean {
+		if (this.isClean) return true
+
+		if (
+			!window.confirm(
+				'You have unsaved changes. Are you sure you want to leave?',
+			)
+		) {
+			e.preventDefault()
+			return false
+		}
+	}
+}

--- a/resources/js/admin/app.ts
+++ b/resources/js/admin/app.ts
@@ -1,4 +1,9 @@
-import { createApp } from "vue"
-import Lightbox from "../Lightbox.vue";
+import {createApp} from 'vue'
+import Lightbox from '../Lightbox.vue'
+import {DirtyStatesRegister} from './DirtyStatesRegister'
 
-createApp(Lightbox).mount("#lightbox-modal")
+if (document.getElementById('lightbox-modal')) {
+	createApp(Lightbox).mount('#lightbox-modal')
+}
+
+new DirtyStatesRegister()

--- a/resources/views/filament/partials/footer-scripts.blade.php
+++ b/resources/views/filament/partials/footer-scripts.blade.php
@@ -1,0 +1,1 @@
+@vite('resources/js/admin/app.ts')


### PR DESCRIPTION
### Starting use cases
- [ ] Confirmation for model-based forms with changes
- [ ] Confirmation for generic forms that have fields

### Implementation
- [ ] Build dirty states register
  - [x] `set` method: `hash` (string), `isDirty` (boolean)
  - [ ] Key for model: hashed model type + ID?
  - [ ] Key for other forms: hashed form ID + fields IDs?
  - [x] `unset` method: `hash`
  - [x] Public computed `isClean` property that reports overall dirtiness or cleanliness of state
- [ ] Navigation watcher
  - [x] Watches for `beforeunload` and any other selected events
  - [x] Checks if register `isClean`
  - [x] Confirms if navigation should happen
- [ ] Reporter implementation
  - [ ] 3 methods matching 3 basic events checked by register
  - [ ] a custom `receive` event defined by the reporter
  - [ ] a `receive` method for listening for the above event and acting accordingly

#### Sample reporter implementation
```javascript
function reportDirty(hashVal, isDirty) {
  dispatchEvent(new CustomEvent('reportDirtyState', {detail: {hashVal, isDirty}})
}

function checkDirty(hashVal, emitBack) {
  dispatchEvent(new CustomEvent('checkDirtyState', {detail: {hashVal, emitBack}})
}

function receiver({detail: {isDirty}}) {
  console.info(`isDirty: ${isDirty}`)
  // some kind of usage here
}

function forgetDirty(hashVal) {
  dispatchEvent(new CustomEvent('forgetDirtyState', {detail: {hashVal}}))
}

let receiveEvent = 'reporter:receive'
window.addEventListener(receiveEvent, receiver)
```
---
Fixes #156