### PR TITLE
Remove risk of boot-time dependency on `pennant` table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,11 @@
 
 - [#204][is_204]: Delete dependabot workflow file
 - [#201][is_201]: Use fallback cache driver for `ImageService` ([#207][pr_207])
+- [#200][is_200]: Remove risk of boot-time dependency on `pennant` table ([#209][pr_209])
 
 [is_184]: https://github.com/JSn1nj4/ElliotDerhay.com/issues/184
+
+[is_200]: https://github.com/JSn1nj4/ElliotDerhay.com/issues/200
 
 [is_201]: https://github.com/JSn1nj4/ElliotDerhay.com/issues/201
 
@@ -24,6 +27,8 @@
 [pr_206]: https://github.com/JSn1nj4/ElliotDerhay.com/pull/206
 
 [pr_207]: https://github.com/JSn1nj4/ElliotDerhay.com/pull/207
+
+[pr_209]: https://github.com/JSn1nj4/ElliotDerhay.com/pull/209
 
 ## Version 2.9.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@
 
 - Set `::selection` color
 - [#184][is_184]: Use Volt for blog ([#206][pr_206])
-- [#204][is_204]: Delete dependabot workflow file
 - [#205][is_205]: Remove direct Alpine dependency
+
+### Fixed
+
+- [#204][is_204]: Delete dependabot workflow file
 - [#201][is_201]: Use fallback cache driver for `ImageService` ([#207][pr_207])
 
 [is_184]: https://github.com/JSn1nj4/ElliotDerhay.com/issues/184

--- a/routes/console.php
+++ b/routes/console.php
@@ -6,20 +6,16 @@ use App\Console\Commands\{GithubEventPullCommand,
 	TokenPruneCommand,
 	TweetPullCommand,
 	TwitterUserUpdateCommand};
-use App\Features\TwitterFeed;
 use App\Jobs\CleanTempStorageJob;
 use Illuminate\Queue\Console\WorkCommand;
 use Illuminate\Support\Facades\Schedule;
-use Laravel\Pennant\Feature;
 
 Schedule::command(GithubEventPullCommand::class)->hourly();
 Schedule::command(GithubUserUpdateCommand::class)->weekly();
 Schedule::command(TokenPruneCommand::class)->daily();
 
-if (Feature::active(TwitterFeed::class)) {
-	Schedule::command(TweetPullCommand::class)->hourly();
-	Schedule::command(TwitterUserUpdateCommand::class)->weekly();
-}
+Schedule::command(TweetPullCommand::class)->hourly();
+Schedule::command(TwitterUserUpdateCommand::class)->weekly();
 
 Schedule::job(CleanTempStorageJob::class)->weekly();
 Schedule::command(WorkCommand::class, ['--stop-when-empty'])->daily();


### PR DESCRIPTION
This becomes a problem if Pennant stores its features in the DB. It does by default and, although that can be change, the cause of this dependency was a bit ridiculous.

Two conditionally-scheduled commands were already configured to bail if their related feature was disabled, so they wouldn't process under that condition anyway.

This resolves this issue by unwrapping these commands in the `routes/console.php` file.

---

Resolve #200