### PR TITLE
JSN-305: Replace Image provider for Faker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Version 2.13.2
+
+### Changes
+
+- JSN-305: Replace Image provider for Faker ([#244][pr_244])
+	- This fixes everything that was using `fake()->image()` for getting placeholder images by providing an alternative
+	  to Faker's default Image provider.
+
+### Fixes
+
+- `ImageFactory` no longer fails to set up placeholder images ([#244][pr_244])
+
+[pr_244]: https://github.com/JSn1nj4/ElliotDerhay.com/pull/244
+
 ## Version 2.13.1
 
 ### Fixes

--- a/_ide_helper.php
+++ b/_ide_helper.php
@@ -11,7 +11,12 @@
  * @author Barry vd. Heuvel <barryvdh@gmail.com>
  * @see https://github.com/barryvdh/laravel-ide-helper
  */
-
+    namespace Faker {
+      /**
+       * @method string image(string|null $dir = null, int $width = 640, int $height = 480, bool $fullPath = true, bool $gray = false, string $format = 'jpg', bool|null $blur = null)
+       */
+      class Generator {}
+    }
     namespace Illuminate\Support\Facades { 
             /**
      * 

--- a/app/DataTransferObjects/QueryParam.php
+++ b/app/DataTransferObjects/QueryParam.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\DataTransferObjects;
+
+
+readonly class QueryParam
+{
+	public const EMPTY_PLACEHOLDER = ':allow_empty:';
+	public mixed $value;
+
+	public function __construct(
+		public string $field,
+		mixed         $value = null,
+		/** @var bool $boolean Query string processors should use this to decide whether a query param should be included empty */
+		public bool   $allow_empty = false)
+	{
+		$this->value = match (true) {
+			$allow_empty && $value === null => self::EMPTY_PLACEHOLDER,
+			default => $value,
+		};
+	}
+}

--- a/app/DataTransferObjects/Result.php
+++ b/app/DataTransferObjects/Result.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\DataTransferObjects;
+
+class Result
+{
+	public function __construct(
+		public bool  $success,
+		public array $data = [],
+		public array $errors = [],
+	) {}
+
+	public function failed(): bool
+	{
+		return $this->success === false;
+	}
+
+	public function hasErrors(): bool
+	{
+		return count($this->errors) > 0;
+	}
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -49,6 +49,11 @@ class AppServiceProvider extends ServiceProvider
 			XService::class,
 			static fn () => new XService(app(XApiCredentials::class)),
 		);
+
+		$this->app->singleton(
+			\Faker\Generator::class . ':' . config('app.faker_locale'),
+			static fn () => \App\Support\Faker\Factory::create(config('app.faker_locale')),
+		);
 	}
 
 	/**

--- a/app/Support/Faker/Factory.php
+++ b/app/Support/Faker/Factory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Support\Faker;
+
+use App\Support\Faker\Providers\LoremPicsum;
+use Faker\Generator;
+
+class Factory extends \Faker\Factory
+{
+	/** @noinspection MissingParentCallInspection */
+	#[\Override]
+	public static function create($locale = \Faker\Factory::DEFAULT_LOCALE): Generator
+	{
+		$generator = new Generator();
+
+		foreach (static::$defaultProviders as $provider) {
+			if ($provider === 'Image') {
+				$generator->addProvider(new LoremPicsum($generator));
+				continue;
+			}
+
+			$providerClassName = self::getProviderClassname($provider, $locale);
+			$generator->addProvider(new $providerClassName($generator));
+		}
+
+		return $generator;
+	}
+}

--- a/app/Support/Faker/Providers/LoremPicsum.php
+++ b/app/Support/Faker/Providers/LoremPicsum.php
@@ -11,7 +11,6 @@ class LoremPicsum extends Base
 	public const BASE_URL = 'https://picsum.photos';
 	public const FORMAT_JPG = 'jpg';
 	public const FORMAT_JPEG = 'jpeg';
-	public const FORMAT_PNG = 'png';
 	public const FORMAT_WEBP = 'webp';
 
 	public static function image(
@@ -100,11 +99,6 @@ class LoremPicsum extends Base
 			));
 		}
 
-		$size = strtr(':w/:h', [
-			':w' => $width,
-			':h' => $height,
-		]);
-
 		$params = [];
 
 		if ($gray === true) {
@@ -122,8 +116,12 @@ class LoremPicsum extends Base
 
 		return strtr(":url/:w/:h.:format:params", [
 			':url' => self::BASE_URL,
-			':size' => $size,
-			':format' => $format,
+			':w' => $width,
+			':h' => $height,
+			':format' => match ($format) {
+				'jpeg' => 'jpg',
+				default => $format,
+			},
 			':params' => count($params) > 0 ? '?' . build_query_string($params) : ''
 		]);
 	}
@@ -138,7 +136,6 @@ class LoremPicsum extends Base
 		return [
 			static::FORMAT_JPG => constant('IMAGETYPE_JPEG'),
 			static::FORMAT_JPEG => constant('IMAGETYPE_JPEG'),
-			static::FORMAT_PNG => constant('IMAGETYPE_PNG'),
 			static::FORMAT_WEBP => constant('IMAGETYPE_WEBP'),
 		];
 	}

--- a/app/Support/Faker/Providers/LoremPicsum.php
+++ b/app/Support/Faker/Providers/LoremPicsum.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Support\Faker\Providers;
+
+use App\DataTransferObjects\QueryParam;
+use Faker\Provider\Base;
+use Illuminate\Support\Number;
+
+class LoremPicsum extends Base
+{
+	public const BASE_URL = 'https://picsum.photos';
+	public const FORMAT_JPG = 'jpg';
+	public const FORMAT_JPEG = 'jpeg';
+	public const FORMAT_PNG = 'png';
+	public const FORMAT_WEBP = 'webp';
+
+	public static function imageUrl(
+		$width = 640,
+		$height = 480,
+		$gray = false,
+		$format = 'png',
+		int|null $blur = null,
+	)
+	{
+		// Validate image format
+		$imageFormats = static::getFormats();
+
+		if (!in_array(strtolower($format), $imageFormats, true)) {
+			throw new \InvalidArgumentException(sprintf(
+				'Invalid image format "%s". Allowable formats are: %s',
+				$format,
+				implode(', ', $imageFormats),
+			));
+		}
+
+		$size = strtr(':w/:h', [
+			':w' => $width,
+			':h' => $height,
+		]);
+
+		$params = [];
+
+		if ($gray === true) {
+			$params[] = new QueryParam('grayscale', allow_empty: true);
+		}
+
+		if ($blur !== null) {
+			$blur = Number::clamp($blur, 1, 10);
+
+			$params[] = match (true) {
+				$blur > 1 => new QueryParam('blur', $blur),
+				default => new QueryParam('blur', allow_empty: true),
+			};
+		}
+
+		return strtr(":url/:w/:h.:format:params", [
+			':url' => self::BASE_URL,
+			':size' => $size,
+			':format' => $format,
+			':params' => count($params) > 0 ? '?' . build_query_string($params) : ''
+		]);
+	}
+
+	public static function getFormats(): array
+	{
+		return array_keys(static::getFormatConstants());
+	}
+
+	public static function getFormatConstants(): array
+	{
+		return [
+			static::FORMAT_JPG => constant('IMAGETYPE_JPEG'),
+			static::FORMAT_JPEG => constant('IMAGETYPE_JPEG'),
+			static::FORMAT_PNG => constant('IMAGETYPE_PNG'),
+			static::FORMAT_WEBP => constant('IMAGETYPE_WEBP'),
+		];
+	}
+}

--- a/app/Support/Faker/Providers/LoremPicsum.php
+++ b/app/Support/Faker/Providers/LoremPicsum.php
@@ -136,8 +136,8 @@ class LoremPicsum extends Base
 
 		return strtr(":url/:w/:h.:format:params", [
 			':url' => self::BASE_URL,
-			':w' => $width,
-			':h' => $height,
+			':w' => Number::clamp($width, 1, 5000),
+			':h' => Number::clamp($height, 1, 5000),
 			':format' => match ($format) {
 				'jpeg' => 'jpg',
 				default => $format,

--- a/app/Support/Faker/Providers/LoremPicsum.php
+++ b/app/Support/Faker/Providers/LoremPicsum.php
@@ -104,7 +104,7 @@ class LoremPicsum extends Base
 		int      $width = 640,
 		int      $height = 480,
 		bool     $gray = false,
-		string   $format = 'png',
+		string   $format = 'jpg',
 		int|null $blur = null,
 	)
 	{

--- a/app/Support/Faker/Providers/LoremPicsum.php
+++ b/app/Support/Faker/Providers/LoremPicsum.php
@@ -69,7 +69,7 @@ class LoremPicsum extends Base
 		int         $height = 480,
 		bool        $fullPath = true,
 		bool        $gray = false,
-		string      $format = 'png',
+		string      $format = 'jpg',
 		bool|null   $blur = null,
 	): false|string|\Exception
 	{

--- a/database/factories/ImageFactory.php
+++ b/database/factories/ImageFactory.php
@@ -84,7 +84,7 @@ class ImageFactory extends Factory
 
 			$temp_path = fake()
 				->unique()
-				->image(storage_path('app/temp'));
+				->image(storage_path('app/temp'), format: 'jpeg');
 		}
 
 		$this->resetTimer();

--- a/database/factories/ImageFactory.php
+++ b/database/factories/ImageFactory.php
@@ -2,8 +2,8 @@
 
 namespace Database\Factories;
 
+use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Database\Eloquent\Factories\Factory;
-use Illuminate\Filesystem\FilesystemAdapter;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Storage;
@@ -14,7 +14,7 @@ use Illuminate\Support\Facades\Storage;
 class ImageFactory extends Factory
 {
 	protected string $diskName = 'public';
-	protected FilesystemAdapter $disk;
+	protected Filesystem $disk;
 	private int|null $timer = null;
 
 	public function __construct(
@@ -105,11 +105,11 @@ class ImageFactory extends Factory
 		$this->timer = null;
 	}
 
-	public function setDisk(string $name, FilesystemAdapter|null $disk = null): static
+	public function setDisk(string $name, Filesystem|null $disk = null): static
 	{
 		$this->diskName = $name;
 
-		$this->disk = is_null($disk) ? Storage::disk($this->diskName) : $disk;
+		$this->disk = $disk ?? Storage::disk($this->diskName);
 
 		return $this;
 	}

--- a/tests/Feature/Support/Faker/Providers/LoremPicsumTest.php
+++ b/tests/Feature/Support/Faker/Providers/LoremPicsumTest.php
@@ -98,7 +98,11 @@ it('fetches and stores a valid image', function (
 	/**
 	 * This one needed `fake()` so the underlying generator would be configured correctly.
 	 *
-	 * Type-hinting (for now) still thinks `image()` is the same method belonging to the deprecated Image provider, but it's actually the one belonging to the new LoremPicsum provider. So all arguments and named params end up being correct underneath.
+	 * Type-hinting might still think `image()` is the same method belonging to the deprecated Image provider. This is due to `\Faker\Generator` including the old `image()` signature in its PHPDoc.
+	 *
+	 * But in this application, `image()` is actually the one belonging to the new LoremPicsum provider. So all arguments and named params end up being correct underneath.
+	 *
+	 * The _ide_helper.php file has an entry for `\Faker\Generator` near the top to try to resolve this.
 	 */
 	$imagePath = fake()->image($disk->path(''), $w, $h, gray: $gray, format: $format, blur: $blur);
 

--- a/tests/Feature/Support/Faker/Providers/LoremPicsumTest.php
+++ b/tests/Feature/Support/Faker/Providers/LoremPicsumTest.php
@@ -95,6 +95,11 @@ it('fetches and stores a valid image', function (
 ) {
 	$disk = Storage::fake('temp');
 
+	/**
+	 * This one needed `fake()` so the underlying generator would be configured correctly.
+	 *
+	 * Type-hinting (for now) still thinks `image()` is the same method belonging to the deprecated Image provider, but it's actually the one belonging to the new LoremPicsum provider. So all arguments and named params end up being correct underneath.
+	 */
 	$imagePath = fake()->image($disk->path(''), $w, $h, gray: $gray, format: $format, blur: $blur);
 
 	expect($imagePath)

--- a/tests/Feature/Support/Faker/Providers/LoremPicsumTest.php
+++ b/tests/Feature/Support/Faker/Providers/LoremPicsumTest.php
@@ -1,0 +1,112 @@
+<?php
+
+use App\Support\Faker\Factory;
+use App\Support\Faker\Providers\LoremPicsum;
+
+$supported_image_formats = ['jpg', 'jpeg', 'webp'];
+$unsupported_image_formats = ['png', 'bmp', 'gif', 'tif', 'ico'];
+
+dataset('random_supported_image_format', function () use ($supported_image_formats) {
+	yield fake()->randomElement($supported_image_formats);
+});
+
+dataset('all_supported_image_formats', $supported_image_formats);
+
+dataset('all_unsupported_image_formats', $unsupported_image_formats);
+
+dataset('random_x_y_coordinates', function () {
+	yield fake()->randomElements(range(-5000, 10000), count: 2);
+});
+
+dataset('random_blur_value', function () {
+	yield fake()->randomElement([null, ...range(-50, 50)]);
+});
+
+it('returns the list of valid image format constants')
+	->expect(LoremPicsum::getFormatConstants())
+	->toContain(IMAGETYPE_JPEG, IMAGETYPE_WEBP);
+
+it('returns the list of valid image formats')
+	->expect(LoremPicsum::getFormats())
+	->toContain(...$supported_image_formats);
+
+it('provides a correctly-formatted image URL', function (
+	int      $w,
+	int      $h,
+	bool     $gray,
+	string   $format,
+	int|null $blur
+) {
+	/**
+	 * @noinspection PhpArgumentWithoutNamedIdentifierInspection
+	 * this imageUrl() method is from a different provider than the default
+	 */
+	$sampleUrl = new LoremPicsum(Factory::create(config('app.faker_locale')))
+		->imageUrl($w, $h, gray: $gray, format: $format, blur: $blur);
+
+	/** @var $expression | goals: test whole string, capture width/height to see if within min/max range */
+	$expression = '/^https:\/\/picsum\.photos(?:\/(?P<x>[0-9]{1,4}))(?:\/(?P<y>[0-9]{1,4}))\.(?:jpg|webp)(?:\?(?:grayscale(?:&blur(?:\=(?P<blur>[0-9]{1,2}))?)?|blur(?:\=(?P<blur_alt>[0-9]{1,2}))?))?$/i';
+
+	preg_match($expression, $sampleUrl, $matches);
+
+	$blur_val = match (true) {
+		!empty($matches['blur']) => (int)$matches['blur'],
+		!empty($matches['blur_alt']) => (int)$matches['blur_alt'],
+		default => null,
+	};
+
+	expect($sampleUrl)->toMatch($expression)
+		->and($matches['x'])->toBeBetween(1, 5000)
+		->and($matches['y'])->toBeBetween(1, 5000)
+		->and($blur_val)
+		->unless($blur_val === null, function ($expectation) {
+			$expectation->toBeBetween(1, 10);
+		});
+})
+	->with('random_x_y_coordinates')
+	->with(function () {
+		yield fake()->boolean();
+	})
+	->with('random_supported_image_format')
+	->with('random_blur_value')
+	->repeat(15);
+
+it('throws when given invalid image formats', function (
+	int      $w,
+	int      $h,
+	bool     $gray,
+	string   $format,
+	int|null $blur
+) {
+	new LoremPicsum(Factory::create(config('app.faker_locale')))
+		->imageUrl($w, $h, gray: $gray, format: $format, blur: $blur);
+})
+	->throws(\InvalidArgumentException::class)
+	->with('random_x_y_coordinates')
+	->with([
+		fake()->boolean(),
+	])
+	->with('all_unsupported_image_formats')
+	->with('random_blur_value');
+
+it('fetches and stores a valid image', function (
+	int      $w,
+	int      $h,
+	bool     $gray,
+	string   $format,
+	int|null $blur
+) {
+	$disk = Storage::fake('temp');
+
+	$imagePath = fake()->image($disk->path(''), $w, $h, gray: $gray, format: $format, blur: $blur);
+
+	expect($imagePath)
+		->toBeFile()
+		->toEndWith("." . $format === 'jpeg' ? 'jpg' : $format)
+		->and(mime_content_type($imagePath))
+		->toBeIn(['image/jpeg', 'image/webp']);
+})
+	->with('random_x_y_coordinates')
+	->with([fake()->boolean()])
+	->with('all_supported_image_formats')
+	->with('random_blur_value');

--- a/tests/Feature/Support/Faker/Providers/LoremPicsumTest.php
+++ b/tests/Feature/Support/Faker/Providers/LoremPicsumTest.php
@@ -6,21 +6,22 @@ use App\Support\Faker\Providers\LoremPicsum;
 $supported_image_formats = ['jpg', 'jpeg', 'webp'];
 $unsupported_image_formats = ['png', 'bmp', 'gif', 'tif', 'ico'];
 
-dataset('random_supported_image_format', function () use ($supported_image_formats) {
-	yield fake()->randomElement($supported_image_formats);
-});
+dataset('random_supported_image_format', [[
+	fn () => fake()->randomElement($supported_image_formats),
+]]);
 
 dataset('all_supported_image_formats', $supported_image_formats);
 
 dataset('all_unsupported_image_formats', $unsupported_image_formats);
 
-dataset('random_x_y_coordinates', function () {
-	yield fake()->randomElements(range(-5000, 10000), count: 2);
-});
+dataset('random_x_y_coordinates', [[
+	fn () => fake()->randomElement(range(-5000, 10000)),
+	fn () => fake()->randomElement(range(-5000, 10000)),
+]]);
 
-dataset('random_blur_value', function () {
-	yield fake()->randomElement([null, ...range(-50, 50)]);
-});
+dataset('random_blur_value', [[
+	fn () => fake()->randomElement([null, ...range(-50, 50)]),
+]]);
 
 it('returns the list of valid image format constants')
 	->expect(LoremPicsum::getFormatConstants())
@@ -64,9 +65,7 @@ it('provides a correctly-formatted image URL', function (
 		});
 })
 	->with('random_x_y_coordinates')
-	->with(function () {
-		yield fake()->boolean();
-	})
+	->with([fn () => fake()->boolean()]) // for grayscale
 	->with('random_supported_image_format')
 	->with('random_blur_value')
 	->repeat(15);
@@ -83,9 +82,7 @@ it('throws when given invalid image formats', function (
 })
 	->throws(\InvalidArgumentException::class)
 	->with('random_x_y_coordinates')
-	->with([
-		fake()->boolean(),
-	])
+	->with([fn () => fake()->boolean()]) // for grayscale
 	->with('all_unsupported_image_formats')
 	->with('random_blur_value');
 
@@ -107,6 +104,6 @@ it('fetches and stores a valid image', function (
 		->toBeIn(['image/jpeg', 'image/webp']);
 })
 	->with('random_x_y_coordinates')
-	->with([fake()->boolean()])
+	->with([fn () => fake()->boolean()]) // for grayscale
 	->with('all_supported_image_formats')
 	->with('random_blur_value');


### PR DESCRIPTION
This registers a new provider for the `image()` method called when using Faker.

The old provider was connecting to placeholder.com which is now shut down.

The new LoremPicsum provider connects to LoremPicsum instead.